### PR TITLE
Current Traceroute min/max tracks current window

### DIFF
--- a/Common/Plotter.cs
+++ b/Common/Plotter.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using SkiaSharp;
+using PlotPingApp.Common;
 
 namespace PlotPingApp
 {
@@ -28,7 +29,7 @@ namespace PlotPingApp
             }
         }
 
-        static internal void RenderTrace(FormsPlot plot, Hop[] hops, Traceroute traceroute, int offset, int windowSize)
+        static internal void RenderTrace(FormsPlot plot, Hop[] hops, Traceroute traceroute, int offset, int windowSize, MinMaxTracker minmaxes)
         {
             plot.Plot.Clear();
 
@@ -38,7 +39,7 @@ namespace PlotPingApp
             Tick[] ticks = hops.Select(t => new Tick(t.hop, t.hop.ToString(), true, false)).ToArray();
 
             double last = 0;
-            MinMax [] minmax = hops.Select(t => traceroute.GetMinMax(t.ipAddress)).ToArray();
+            MinMax [] minmax = hops.Select(t => minmaxes.Get(t.ipAddress)).ToArray();
 
             double[] lower = minmax.Select(x => x != null ? x.min : last).ToArray();
             double[] upper = minmax.Select(x => x != null ? x.max : last).ToArray();
@@ -66,7 +67,7 @@ namespace PlotPingApp
             plot.Plot.YAxis.SetTicks(latencyAxis);
             plot.Plot.YAxis.AxisTicks.MinorTickVisible = false;
             plot.Plot.SetAxisLimits(0.8, hops.Length + 0.2, 0, latencyMax);
-            plot.Plot.Title("Traceroute Results");
+            plot.Plot.Title(offset == 0 ? "Current Traceroute" : "Traceroute @ " + hops[0].timestamp.ToString("yyyy-MM-dd HH:mm:ss"));
             plot.Plot.Legend();
 
 

--- a/Common/Plotter.cs
+++ b/Common/Plotter.cs
@@ -29,7 +29,7 @@ namespace PlotPingApp
             }
         }
 
-        static internal void RenderTrace(FormsPlot plot, Hop[] hops, Traceroute traceroute, int offset, int windowSize, MinMaxTracker minmaxes)
+        static internal void RenderTrace(FormsPlot plot, Hop[] hops, Traceroute traceroute, bool isCurrent, int windowSize, MinMaxTracker minmaxes)
         {
             plot.Plot.Clear();
 
@@ -67,7 +67,7 @@ namespace PlotPingApp
             plot.Plot.YAxis.SetTicks(latencyAxis);
             plot.Plot.YAxis.AxisTicks.MinorTickVisible = false;
             plot.Plot.SetAxisLimits(0.8, hops.Length + 0.2, 0, latencyMax);
-            plot.Plot.Title(offset == 0 ? "Current Traceroute" : "Traceroute @ " + hops[0].timestamp.ToString("yyyy-MM-dd HH:mm:ss"));
+            plot.Plot.Title(isCurrent ? "Current Traceroute" : "Traceroute @ " + hops[0].timestamp.ToString("yyyy-MM-dd HH:mm:ss"));
             plot.Plot.Legend();
 
 

--- a/Common/Settings.Designer.cs
+++ b/Common/Settings.Designer.cs
@@ -32,6 +32,10 @@
             this.label1 = new System.Windows.Forms.Label();
             this.selectFolderButton = new System.Windows.Forms.Button();
             this.buttonOk = new System.Windows.Forms.Button();
+            this.settingsPanel = new System.Windows.Forms.Panel();
+            this.activeTracksWindowCheckBox = new System.Windows.Forms.CheckBox();
+            this.label2 = new System.Windows.Forms.Label();
+            this.settingsPanel.SuspendLayout();
             this.SuspendLayout();
             // 
             // logOutputFolder
@@ -74,11 +78,41 @@
             this.buttonOk.Text = "OK";
             this.buttonOk.UseVisualStyleBackColor = true;
             // 
+            // settingsPanel
+            // 
+            this.settingsPanel.Controls.Add(this.activeTracksWindowCheckBox);
+            this.settingsPanel.Location = new System.Drawing.Point(15, 90);
+            this.settingsPanel.Name = "settingsPanel";
+            this.settingsPanel.Size = new System.Drawing.Size(585, 115);
+            this.settingsPanel.TabIndex = 4;
+            // 
+            // activeTracksWindowCheckBox
+            // 
+            this.activeTracksWindowCheckBox.AutoSize = true;
+            this.activeTracksWindowCheckBox.Location = new System.Drawing.Point(15, 13);
+            this.activeTracksWindowCheckBox.Name = "activeTracksWindowCheckBox";
+            this.activeTracksWindowCheckBox.Size = new System.Drawing.Size(199, 20);
+            this.activeTracksWindowCheckBox.TabIndex = 4;
+            this.activeTracksWindowCheckBox.Text = "Active Tracks Window Offset";
+            this.activeTracksWindowCheckBox.UseVisualStyleBackColor = true;
+            this.activeTracksWindowCheckBox.CheckedChanged += new System.EventHandler(this.activeTracksWindow_CheckedChanged);
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(12, 71);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(55, 16);
+            this.label2.TabIndex = 5;
+            this.label2.Text = "Settings";
+            // 
             // Settings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(612, 255);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.settingsPanel);
             this.Controls.Add(this.buttonOk);
             this.Controls.Add(this.selectFolderButton);
             this.Controls.Add(this.label1);
@@ -90,6 +124,8 @@
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Plot Ping Settings";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Settings_FormClosing);
+            this.settingsPanel.ResumeLayout(false);
+            this.settingsPanel.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -101,5 +137,8 @@
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Button selectFolderButton;
         private System.Windows.Forms.Button buttonOk;
+        private System.Windows.Forms.Panel settingsPanel;
+        private System.Windows.Forms.CheckBox activeTracksWindowCheckBox;
+        private System.Windows.Forms.Label label2;
     }
 }

--- a/Common/Settings.cs
+++ b/Common/Settings.cs
@@ -23,7 +23,8 @@ namespace PlotPingApp
         private static Dictionary<string, string> settings = new Dictionary<string, string>()
         {
             // Default settings
-            ["LogOutputFolder"] = GetDefaultLogOutputFolder()
+            ["LogOutputFolder"] = GetDefaultLogOutputFolder(),
+            ["ActiveTracksWindow"] = "true",
         };
 
         internal static string Get(string key)
@@ -38,6 +39,10 @@ namespace PlotPingApp
         }
 
         internal static string LogOutputFolder { get { return Get("LogOutputFolder"); } set { Set("LogOutputFolder", value); } }
+        internal static bool ActiveTracksWindow { 
+            get { return Get("ActiveTracksWindow") == "true"; } 
+            set { Set("ActiveTracksWindow", value ? "true" : "false"); }
+        }
 
         internal static void LoadSettings()
         {
@@ -62,6 +67,7 @@ namespace PlotPingApp
             InitializeComponent();
             LoadSettings();
             logOutputFolder.Text = LogOutputFolder;
+            activeTracksWindowCheckBox.Checked = ActiveTracksWindow;
             if (logOutputFolder.Text == "")
             {
                 LogOutputFolder = logOutputFolder.Text = GetDefaultLogOutputFolder();
@@ -103,6 +109,11 @@ namespace PlotPingApp
             LoadSettings();
             Set(form.Name + ".Bounds", JsonConvert.SerializeObject(form.Bounds));
             SaveSettings();
+        }
+
+        private void activeTracksWindow_CheckedChanged(object sender, EventArgs e)
+        {
+            ActiveTracksWindow = activeTracksWindowCheckBox.Checked;
         }
     }
 }


### PR DESCRIPTION
Changed the current trace (hop data + current trace graph) to use the currently selected window to calculate min/max/avg/pl values.

Also added an option (Active Trace Tracks Window) to allow the current trace to show historical data when the window slider is not at offset 0. This allows the user to scroll back through the trace history and look at individual traces.